### PR TITLE
fix: Reduce serving content frames online for new frames

### DIFF
--- a/watchdog/watchdog_app.py
+++ b/watchdog/watchdog_app.py
@@ -190,8 +190,8 @@ def generate_camera(camera:VideoCamera, frame_rate = DEFAULT_FPS):
                 play_time += frame_duration
                 delta_time = play_time - expected_play_time # Carries on to next frame sleep request
 
-            yield (b'--frame\r\n'
-                b'Content-Type: image/jpeg\r\n\r\n' + frame + b'\r\n\r\n')
+                yield (b'--frame\r\n'
+                    b'Content-Type: image/jpeg\r\n\r\n' + frame + b'\r\n\r\n')
 
 def load_camera(video_list:list, frame_rate=DEFAULT_FPS):
     """Initialize camera object from cv2.VideoCapture with video queue"""


### PR DESCRIPTION
## Description ✍️

Reduce networking stream updates for same frame

## Closes issue(s) 🤺

[PROTO-29](https://neurealities.atlassian.net/browse/PROTO-29?atlOrigin=eyJpIjoiZTk1Y2JkZGI5NWY4NDhhZmEwM2Q1ZWI2ODM0MzQ3MDgiLCJwIjoiaiJ9)

## How to test / repo 👣

1. `./bin/up/
2. http://127.0.0.1:5000/live
3. http://127.0.0.1:7860/ -> Create video for small text
4. Using developr tools on the live page, network tab, the amount of data transfered should be in the MB range, not hundreds of GB as before

## Screenshots 📸

<img width="407" height="31" alt="image" src="https://github.com/user-attachments/assets/a1eacbdd-f7f7-4dd9-889e-1d16451ede36" />

## What GIF best describes this PR? 🤓

![NEtwork overload](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjFiajVjbHRzaHIwZml4eHMyNjU5Y3FwM3poMmk3OGI4OTV3bThtYyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l2Jee5TqCSzVnClUY/giphy.gif)

## Changes include 🏭

- [ ] Chore (non-breaking change that doesn't affect functionality, like a refactor or cleanup)
- [X] Fix (non-breaking change that solves an issue/bug)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Reminders 🛎️

- All my tests have passed
- I have pulled the latest version of main
- I have updated the README if needed

## Other comments 💭
